### PR TITLE
Encapsulate `volumeCredits` calculation

### DIFF
--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -1,6 +1,5 @@
 class StatementPrinter {
     func print(_ invoice: Invoice, _ plays: Dictionary<String, Play>) throws -> String {
-        let volumeCredits = try totalVolumeCreditsFor(invoice.performances)
         var result = "Statement for \(invoice.customer)\n"
         
         let frmt = NumberFormatter()
@@ -12,7 +11,7 @@ class StatementPrinter {
             result += "  \(try playFor(playID: performance.playID).name): \(frmt.string(for: NSNumber(value: Double((try performanceDollarCostTotalFor(genre: try playFor(playID: performance.playID).type, attendance: performance.audience)))))!) (\(performance.audience) seats)\n"
         }
         result += "Amount owed is \(frmt.string(for: NSNumber(value: Double(try totalCostOf(invoice.performances))))!)\n"
-        result += "You earned \(volumeCredits) credits\n"
+        result += "You earned \(try totalVolumeCreditsFor(invoice.performances)) credits\n"
         return result
         
         func totalVolumeCreditsFor(_ performances: [Performance]) throws -> Int {

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -10,7 +10,9 @@ class StatementPrinter {
         for performance in invoice.performances {
             // add volume credits
             volumeCredits += volumeCreditsFor(genre: try playFor(playID: performance.playID).type, audienceCount: performance.audience)
-            
+        }
+        
+        for performance in invoice.performances {
             // print line for this order
             result += "  \(try playFor(playID: performance.playID).name): \(frmt.string(for: NSNumber(value: Double((try performanceDollarCostTotalFor(genre: try playFor(playID: performance.playID).type, attendance: performance.audience)))))!) (\(performance.audience) seats)\n"
         }
@@ -24,6 +26,7 @@ class StatementPrinter {
             // add extra credit for every ten comedy attendees
             if ("comedy" == genre) {
                 volumeCredits += Int(round(Double(audienceCount / 5)))
+                result += Int(round(Double(audienceCount / 5)))
             }
             return result
         }

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -9,11 +9,7 @@ class StatementPrinter {
         
         for performance in invoice.performances {
             // add volume credits
-            volumeCredits += max(performance.audience - 30, 0)
-            // add extra credit for every ten comedy attendees
-            if ("comedy" == (try playFor(playID: performance.playID).type)) {
-                volumeCredits += Int(round(Double(performance.audience / 5)))
-            }
+            volumeCredits += volumeCreditsFor(genre: try playFor(playID: performance.playID).type, audienceCount: performance.audience)
             
             // print line for this order
             result += "  \(try playFor(playID: performance.playID).name): \(frmt.string(for: NSNumber(value: Double((try performanceDollarCostTotalFor(genre: try playFor(playID: performance.playID).type, attendance: performance.audience)))))!) (\(performance.audience) seats)\n"
@@ -21,6 +17,16 @@ class StatementPrinter {
         result += "Amount owed is \(frmt.string(for: NSNumber(value: Double(try totalCostOf(invoice.performances))))!)\n"
         result += "You earned \(volumeCredits) credits\n"
         return result
+        
+        func volumeCreditsFor(genre: String, audienceCount: Int) -> Int {
+            // add volume credits
+            var result = max(audienceCount - 30, 0)
+            // add extra credit for every ten comedy attendees
+            if ("comedy" == genre) {
+                volumeCredits += Int(round(Double(audienceCount / 5)))
+            }
+            return result
+        }
         
         func totalCostOf(_ performances: [Performance]) throws -> Int {
             var result = 0

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -1,16 +1,11 @@
 class StatementPrinter {
     func print(_ invoice: Invoice, _ plays: Dictionary<String, Play>) throws -> String {
-        var volumeCredits = 0
+        let volumeCredits = try totalVolumeCreditsFor(invoice.performances)
         var result = "Statement for \(invoice.customer)\n"
         
         let frmt = NumberFormatter()
         frmt.numberStyle = .currency
         frmt.locale = Locale(identifier: "en_US")
-        
-        for performance in invoice.performances {
-            // add volume credits
-            volumeCredits += volumeCreditsFor(genre: try playFor(playID: performance.playID).type, audienceCount: performance.audience)
-        }
         
         for performance in invoice.performances {
             // print line for this order
@@ -20,12 +15,21 @@ class StatementPrinter {
         result += "You earned \(volumeCredits) credits\n"
         return result
         
+        func totalVolumeCreditsFor(_ performances: [Performance]) throws -> Int {
+            var result = 0
+            for performance in invoice.performances {
+                // add volume credits
+                result += volumeCreditsFor(genre: try playFor(playID: performance.playID).type, audienceCount: performance.audience)
+            }
+            
+            return result
+        }
+        
         func volumeCreditsFor(genre: String, audienceCount: Int) -> Int {
             // add volume credits
             var result = max(audienceCount - 30, 0)
             // add extra credit for every ten comedy attendees
             if ("comedy" == genre) {
-                volumeCredits += Int(round(Double(audienceCount / 5)))
                 result += Int(round(Double(audienceCount / 5)))
             }
             return result

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -1,5 +1,5 @@
 class StatementPrinter {
-    func print(_ invoice: Invoice, _ plays: Dictionary<String, Play>) throws -> String {
+    func formattedStatementText(_ invoice: Invoice, _ plays: Dictionary<String, Play>) throws -> String {
         var result = "Statement for \(invoice.customer)\n"
         
         let frmt = NumberFormatter()

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
@@ -30,7 +30,7 @@ class StatementPrinterTests: XCTestCase {
         )
         
         let statementPrinter = StatementPrinter()
-        let result = try statementPrinter.print(invoice, plays)
+        let result = try statementPrinter.formattedStatementText(invoice, plays)
         
         XCTAssertEqual(result, expected)
     }
@@ -49,7 +49,7 @@ class StatementPrinterTests: XCTestCase {
         )
         
         let statementPrinter = StatementPrinter()
-        XCTAssertThrowsError(try statementPrinter.print(invoice, plays))        
+        XCTAssertThrowsError(try statementPrinter.formattedStatementText(invoice, plays))        
     }
     
     func test_print_throwsErrorOnUnkownPlayType() {
@@ -67,7 +67,7 @@ class StatementPrinterTests: XCTestCase {
         )
         
         let statementPrinter = StatementPrinter()
-        XCTAssertThrowsError(try statementPrinter.print(invoice, plays))
+        XCTAssertThrowsError(try statementPrinter.formattedStatementText(invoice, plays))
     }
 }
 


### PR DESCRIPTION
Encapsulate `volumeCredits` calculation

Split loop to isolate `volumeCredits` accrual from statement line item construction for individual performances

Encapsulate summation of volume credits from performances in helper method

Inline `volumeCredits` variable

Rename method to better communicate what it generates