### PR TITLE
Create `StatementData` struct to encapsulate text generation dependencies. Apply it to the customer name.

### DIFF
--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -15,7 +15,7 @@ class StatementPrinter {
         
         for performance in invoice.performances {
             // print line for this order
-            result += "  \(try playFor(playID: performance.playID).name):" + " \(frmt.string(for: NSNumber(value: Double((try performanceDollarCostTotalFor(genre: try playFor(playID: performance.playID).type, attendance: performance.audience)))))!) (\(performance.audience) seats)\n"
+            result += "  \(try playFor(playID: performance.playID).name):" + " \(frmt.string(for: NSNumber(value: Double((try performanceDollarCostTotalFor(genre: try playFor(playID: performance.playID).type, attendance: performance.audience)))))!)" + " (\(performance.audience) seats)\n"
         }
         result += "Amount owed is \(frmt.string(for: NSNumber(value: Double(try totalCostOf(invoice.performances))))!)\n"
         result += "You earned \(try totalVolumeCreditsFor(invoice.performances)) credits\n"

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -4,7 +4,9 @@ class StatementPrinter {
     }
     
     func formattedStatementText(_ invoice: Invoice, _ plays: Dictionary<String, Play>) throws -> String {
-        let statementData = StatementData(customerName: invoice.customer)
+        let statementData = StatementData(
+            customerName: invoice.customer
+        )
         var result = "Statement for \(statementData.customerName)\n"
         
         let frmt = NumberFormatter()
@@ -13,7 +15,7 @@ class StatementPrinter {
         
         for performance in invoice.performances {
             // print line for this order
-            result += "  \(try playFor(playID: performance.playID).name): \(frmt.string(for: NSNumber(value: Double((try performanceDollarCostTotalFor(genre: try playFor(playID: performance.playID).type, attendance: performance.audience)))))!) (\(performance.audience) seats)\n"
+            result += "  \(try playFor(playID: performance.playID).name):" + " \(frmt.string(for: NSNumber(value: Double((try performanceDollarCostTotalFor(genre: try playFor(playID: performance.playID).type, attendance: performance.audience)))))!) (\(performance.audience) seats)\n"
         }
         result += "Amount owed is \(frmt.string(for: NSNumber(value: Double(try totalCostOf(invoice.performances))))!)\n"
         result += "You earned \(try totalVolumeCreditsFor(invoice.performances)) credits\n"

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -2,6 +2,10 @@ protocol StatementProvider {
     func formattedStatement(from statementData: StatementData) -> String
 }
 
+protocol StatementDataProvider {
+    func statementData(_ invoice: Invoice, _ plays: Dictionary<String, Play>) throws -> StatementData
+}
+
 struct StatementData {
     let customerName: String
     let costLineItemsData: [(String, Int, Int)]
@@ -25,16 +29,16 @@ class StatementPrinter: StatementProvider {
         result += "You earned \(statementData.totalVolumeCredits) credits\n"
         return result
     }
-    
-    func formattedStatementText(_ invoice: Invoice, _ plays: Dictionary<String, Play>) throws -> String {
-        let statementData = StatementData(
+}
+
+extension StatementPrinter: StatementDataProvider {
+    func statementData(_ invoice: Invoice, _ plays: Dictionary<String, Play>) throws -> StatementData {
+        return try StatementData(
             customerName: invoice.customer,
-            costLineItemsData: try invoice.performances.map(statementCostLineData), 
-            totalCost: try invoice.performances.map(statementCostLineData).reduce(into: 0) { $0 += $1.1 },
-            totalVolumeCredits: try totalVolumeCreditsFor(invoice.performances)
+            costLineItemsData: invoice.performances.map(statementCostLineData),
+            totalCost: invoice.performances.map(statementCostLineData).reduce(into: 0) { $0 += $1.1 },
+            totalVolumeCredits: totalVolumeCreditsFor(invoice.performances)
         )
-        
-        return formattedStatement(from: statementData)
         // MARK: Helpers
         
         func statementCostLineData(_ performance: Performance) throws -> (String, Int, Int) {

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -3,13 +3,15 @@ class StatementPrinter {
         let customerName: String
         let costLineItemsData: [(String, Int, Int)]
         let totalCost: Int
+        let totalVolumeCredits: Int
     }
     
     func formattedStatementText(_ invoice: Invoice, _ plays: Dictionary<String, Play>) throws -> String {
         let statementData = StatementData(
             customerName: invoice.customer,
             costLineItemsData: try invoice.performances.map(statementCostLineData), 
-            totalCost: try invoice.performances.map(statementCostLineData).reduce(into: 0) { $0 += $1.1 }
+            totalCost: try invoice.performances.map(statementCostLineData).reduce(into: 0) { $0 += $1.1 },
+            totalVolumeCredits: try totalVolumeCreditsFor(invoice.performances)
         )
         var result = "Statement for \(statementData.customerName)\n"
         
@@ -22,7 +24,7 @@ class StatementPrinter {
             result += "  \(costLineItem.0):" + " \(frmt.string(for: NSNumber(value: Double((costLineItem.1))))!)" + " (\(costLineItem.2) seats)\n"
         }
         result += "Amount owed is \(frmt.string(for: NSNumber(value: Double(statementData.totalCost)))!)\n"
-        result += "You earned \(try totalVolumeCreditsFor(invoice.performances)) credits\n"
+        result += "You earned \(statementData.totalVolumeCredits) credits\n"
         return result
         
         // MARK: Helpers

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -1,6 +1,11 @@
 class StatementPrinter {
+    struct StatementData {
+        let customerName: String
+    }
+    
     func formattedStatementText(_ invoice: Invoice, _ plays: Dictionary<String, Play>) throws -> String {
-        var result = "Statement for \(invoice.customer)\n"
+        let statementData = StatementData(customerName: invoice.customer)
+        var result = "Statement for \(statementData.customerName)\n"
         
         let frmt = NumberFormatter()
         frmt.numberStyle = .currency

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -1,11 +1,13 @@
 class StatementPrinter {
     struct StatementData {
         let customerName: String
+        let costLineItemsData: [(String, Int, Int)]
     }
     
     func formattedStatementText(_ invoice: Invoice, _ plays: Dictionary<String, Play>) throws -> String {
         let statementData = StatementData(
-            customerName: invoice.customer
+            customerName: invoice.customer,
+            costLineItemsData: try invoice.performances.map(statementLineData)
         )
         var result = "Statement for \(statementData.customerName)\n"
         
@@ -13,9 +15,9 @@ class StatementPrinter {
         frmt.numberStyle = .currency
         frmt.locale = Locale(identifier: "en_US")
         
-        for performance in invoice.performances {
+        for costLineItem in statementData.costLineItemsData {
             // print line for this order
-            result += "  \(try statementLineData(performance).0):" + " \(frmt.string(for: NSNumber(value: Double((try statementLineData(performance).1))))!)" + " (\(try statementLineData(performance).2) seats)\n"
+            result += "  \(costLineItem.0):" + " \(frmt.string(for: NSNumber(value: Double((costLineItem.1))))!)" + " (\(costLineItem.2) seats)\n"
         }
         result += "Amount owed is \(frmt.string(for: NSNumber(value: Double(try totalCostOf(invoice.performances))))!)\n"
         result += "You earned \(try totalVolumeCreditsFor(invoice.performances)) credits\n"

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -15,11 +15,17 @@ class StatementPrinter {
         
         for performance in invoice.performances {
             // print line for this order
-            result += "  \(try playFor(playID: performance.playID).name):" + " \(frmt.string(for: NSNumber(value: Double((try performanceDollarCostTotalFor(genre: try playFor(playID: performance.playID).type, attendance: performance.audience)))))!)" + " (\(performance.audience) seats)\n"
+            result += "  \(try statementLineData(performance)):" + " \(frmt.string(for: NSNumber(value: Double((try performanceDollarCostTotalFor(genre: try playFor(playID: performance.playID).type, attendance: performance.audience)))))!)" + " (\(performance.audience) seats)\n"
         }
         result += "Amount owed is \(frmt.string(for: NSNumber(value: Double(try totalCostOf(invoice.performances))))!)\n"
         result += "You earned \(try totalVolumeCreditsFor(invoice.performances)) credits\n"
         return result
+        
+        // MARK: Helpers
+        
+        func statementLineData(_ performance: Performance) throws -> (String) {
+            (try playFor(playID: performance.playID).name)
+        }
         
         func totalVolumeCreditsFor(_ performances: [Performance]) throws -> Int {
             var result = 0

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -15,7 +15,7 @@ class StatementPrinter {
         
         for performance in invoice.performances {
             // print line for this order
-            result += "  \(try statementLineData(performance)):" + " \(frmt.string(for: NSNumber(value: Double((try performanceDollarCostTotalFor(genre: try playFor(playID: performance.playID).type, attendance: performance.audience)))))!)" + " (\(performance.audience) seats)\n"
+            result += "  \(try statementLineData(performance).0):" + " \(frmt.string(for: NSNumber(value: Double((try statementLineData(performance).1))))!)" + " (\(performance.audience) seats)\n"
         }
         result += "Amount owed is \(frmt.string(for: NSNumber(value: Double(try totalCostOf(invoice.performances))))!)\n"
         result += "You earned \(try totalVolumeCreditsFor(invoice.performances)) credits\n"
@@ -23,8 +23,8 @@ class StatementPrinter {
         
         // MARK: Helpers
         
-        func statementLineData(_ performance: Performance) throws -> (String) {
-            (try playFor(playID: performance.playID).name)
+        func statementLineData(_ performance: Performance) throws -> (String, Int) {
+            (try playFor(playID: performance.playID).name, try performanceDollarCostTotalFor(genre: try playFor(playID: performance.playID).type, attendance: performance.audience))
         }
         
         func totalVolumeCreditsFor(_ performances: [Performance]) throws -> Int {

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -15,7 +15,7 @@ class StatementPrinter {
         
         for performance in invoice.performances {
             // print line for this order
-            result += "  \(try statementLineData(performance).0):" + " \(frmt.string(for: NSNumber(value: Double((try statementLineData(performance).1))))!)" + " (\(performance.audience) seats)\n"
+            result += "  \(try statementLineData(performance).0):" + " \(frmt.string(for: NSNumber(value: Double((try statementLineData(performance).1))))!)" + " (\(try statementLineData(performance).2) seats)\n"
         }
         result += "Amount owed is \(frmt.string(for: NSNumber(value: Double(try totalCostOf(invoice.performances))))!)\n"
         result += "You earned \(try totalVolumeCreditsFor(invoice.performances)) credits\n"
@@ -23,8 +23,10 @@ class StatementPrinter {
         
         // MARK: Helpers
         
-        func statementLineData(_ performance: Performance) throws -> (String, Int) {
-            (try playFor(playID: performance.playID).name, try performanceDollarCostTotalFor(genre: try playFor(playID: performance.playID).type, attendance: performance.audience))
+        func statementLineData(_ performance: Performance) throws -> (String, Int, Int) {
+            (try playFor(playID: performance.playID).name,
+             try performanceDollarCostTotalFor(genre: try playFor(playID: performance.playID).type, attendance: performance.audience),
+             performance.audience)
         }
         
         func totalVolumeCreditsFor(_ performances: [Performance]) throws -> Int {

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
@@ -29,8 +29,10 @@ class StatementPrinterTests: XCTestCase {
             ]
         )
         
-        let statementPrinter = StatementPrinter()
-        let result = try statementPrinter.formattedStatementText(invoice, plays)
+        let sut: StatementProvider = StatementPrinter()
+        let statementDataProvider: StatementDataProvider = StatementPrinter()
+        let statementData = try statementDataProvider.statementData(invoice, plays)
+        let result = sut.formattedStatement(from: statementData)
         
         XCTAssertEqual(result, expected)
     }
@@ -48,8 +50,9 @@ class StatementPrinterTests: XCTestCase {
             ]
         )
         
-        let statementPrinter = StatementPrinter()
-        XCTAssertThrowsError(try statementPrinter.formattedStatementText(invoice, plays))        
+        let sut: StatementDataProvider = StatementPrinter()
+        
+        XCTAssertThrowsError(try sut.statementData(invoice, plays))
     }
     
     func test_print_throwsErrorOnUnkownPlayType() {
@@ -66,8 +69,9 @@ class StatementPrinterTests: XCTestCase {
             ]
         )
         
-        let statementPrinter = StatementPrinter()
-        XCTAssertThrowsError(try statementPrinter.formattedStatementText(invoice, plays))
+        let sut: StatementDataProvider = StatementPrinter()
+        
+        XCTAssertThrowsError(try sut.statementData(invoice, plays))
     }
 }
 


### PR DESCRIPTION
### TL;DR

Refactored the StatementPrinter class to implement protocols for `<StatementProvider>` and `<StatementDataProvider>` to separate those concerns in preparation for adding HTML printing support

### What changed?

- Added protocols `StatementProvider` and `StatementDataProvider`
- Implemented methods for `formattedStatement` and `statementData` in `StatementPrinter`
- Created struct `StatementData` to hold statement information

### How to test?

- Run the test cases provided in StatementPrinterTests

### Why make this change?

This change improves the modularity and extensibility of the StatementPrinter class by separating concerns and providing clear interfaces for data handling and presentation.

---

Create `StatementData` struct to encapsulate text generation dependencies. Apply it to the customer name.

Isolate play name order line string

Isolate order line performance cost amount and, consequently seats (audience count)

Extract and abstract play name value into group for dependencies of the statement line

Extract performance cost value to separate it from the concerns of formatting.

Separate formatting concerns from data mapping by abstracting the `Performance` data retrieval usage details with a helper function

Encapsulate line item data values in `StatementData`

Encapsulate cost of all performances in `StatementData`

Hide total volume credits data source details, from formatting, inside `StatementData`

Abstract statement generation in protocol and encapsulate current logic in conformance

Encapsulate statement value creation in `<StatementDataProvider>` segregated interface. Update tests to reference these separated concerns

Create 'Charge` typealias and update `StatementData` to use it for the charge lines instead of direct reference to tuple and improve readability