### PR TITLE
Encapsulate calculation of cost for tragedy genre performances in `AmountCalculator`

### DIFF
--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata.xcodeproj/project.pbxproj
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		104F7D91232830EF00665957 /* Performance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 104F7D90232830EF00665957 /* Performance.swift */; };
 		104F7D932328312700665957 /* Invoice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 104F7D922328312600665957 /* Invoice.swift */; };
 		104F7D95232831E000665957 /* StatementPrinter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 104F7D94232831E000665957 /* StatementPrinter.swift */; };
+		8C7BE0D42C1690BD000D9945 /* GenreCostProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C7BE0D32C1690BD000D9945 /* GenreCostProvider.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -37,6 +38,7 @@
 		104F7D90232830EF00665957 /* Performance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Performance.swift; sourceTree = "<group>"; };
 		104F7D922328312600665957 /* Invoice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Invoice.swift; sourceTree = "<group>"; };
 		104F7D94232831E000665957 /* StatementPrinter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatementPrinter.swift; sourceTree = "<group>"; };
+		8C7BE0D32C1690BD000D9945 /* GenreCostProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenreCostProvider.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +87,7 @@
 				104F7D90232830EF00665957 /* Performance.swift */,
 				104F7D922328312600665957 /* Invoice.swift */,
 				104F7D94232831E000665957 /* StatementPrinter.swift */,
+				8C7BE0D32C1690BD000D9945 /* GenreCostProvider.swift */,
 			);
 			path = "Theatrical-Players-Refactoring-Kata";
 			sourceTree = "<group>";
@@ -210,6 +213,7 @@
 				104F7D91232830EF00665957 /* Performance.swift in Sources */,
 				104F7D932328312700665957 /* Invoice.swift in Sources */,
 				104F7D95232831E000665957 /* StatementPrinter.swift in Sources */,
+				8C7BE0D42C1690BD000D9945 /* GenreCostProvider.swift in Sources */,
 				104F7D8F2328305A00665957 /* Play.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata.xcodeproj/project.pbxproj
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		104F7D91232830EF00665957 /* Performance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 104F7D90232830EF00665957 /* Performance.swift */; };
 		104F7D932328312700665957 /* Invoice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 104F7D922328312600665957 /* Invoice.swift */; };
 		104F7D95232831E000665957 /* StatementPrinter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 104F7D94232831E000665957 /* StatementPrinter.swift */; };
-		8C7BE0D42C1690BD000D9945 /* GenreCostProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C7BE0D32C1690BD000D9945 /* GenreCostProvider.swift */; };
+		8C7BE0D42C1690BD000D9945 /* GenreDollarCostProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C7BE0D32C1690BD000D9945 /* GenreDollarCostProvider.swift */; };
 		8C7BE0D72C169148000D9945 /* GenreAmountProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C7BE0D52C169114000D9945 /* GenreAmountProviderTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -39,7 +39,7 @@
 		104F7D90232830EF00665957 /* Performance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Performance.swift; sourceTree = "<group>"; };
 		104F7D922328312600665957 /* Invoice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Invoice.swift; sourceTree = "<group>"; };
 		104F7D94232831E000665957 /* StatementPrinter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatementPrinter.swift; sourceTree = "<group>"; };
-		8C7BE0D32C1690BD000D9945 /* GenreCostProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenreCostProvider.swift; sourceTree = "<group>"; };
+		8C7BE0D32C1690BD000D9945 /* GenreDollarCostProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenreDollarCostProvider.swift; sourceTree = "<group>"; };
 		8C7BE0D52C169114000D9945 /* GenreAmountProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenreAmountProviderTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -89,7 +89,7 @@
 				104F7D90232830EF00665957 /* Performance.swift */,
 				104F7D922328312600665957 /* Invoice.swift */,
 				104F7D94232831E000665957 /* StatementPrinter.swift */,
-				8C7BE0D32C1690BD000D9945 /* GenreCostProvider.swift */,
+				8C7BE0D32C1690BD000D9945 /* GenreDollarCostProvider.swift */,
 				8C7BE0D52C169114000D9945 /* GenreAmountProviderTests.swift */,
 			);
 			path = "Theatrical-Players-Refactoring-Kata";
@@ -216,7 +216,7 @@
 				104F7D91232830EF00665957 /* Performance.swift in Sources */,
 				104F7D932328312700665957 /* Invoice.swift in Sources */,
 				104F7D95232831E000665957 /* StatementPrinter.swift in Sources */,
-				8C7BE0D42C1690BD000D9945 /* GenreCostProvider.swift in Sources */,
+				8C7BE0D42C1690BD000D9945 /* GenreDollarCostProvider.swift in Sources */,
 				104F7D8F2328305A00665957 /* Play.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata.xcodeproj/project.pbxproj
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		104F7D932328312700665957 /* Invoice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 104F7D922328312600665957 /* Invoice.swift */; };
 		104F7D95232831E000665957 /* StatementPrinter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 104F7D94232831E000665957 /* StatementPrinter.swift */; };
 		8C7BE0D42C1690BD000D9945 /* GenreCostProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C7BE0D32C1690BD000D9945 /* GenreCostProvider.swift */; };
+		8C7BE0D72C169148000D9945 /* GenreAmountProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C7BE0D52C169114000D9945 /* GenreAmountProviderTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -39,6 +40,7 @@
 		104F7D922328312600665957 /* Invoice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Invoice.swift; sourceTree = "<group>"; };
 		104F7D94232831E000665957 /* StatementPrinter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatementPrinter.swift; sourceTree = "<group>"; };
 		8C7BE0D32C1690BD000D9945 /* GenreCostProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenreCostProvider.swift; sourceTree = "<group>"; };
+		8C7BE0D52C169114000D9945 /* GenreAmountProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenreAmountProviderTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -88,6 +90,7 @@
 				104F7D922328312600665957 /* Invoice.swift */,
 				104F7D94232831E000665957 /* StatementPrinter.swift */,
 				8C7BE0D32C1690BD000D9945 /* GenreCostProvider.swift */,
+				8C7BE0D52C169114000D9945 /* GenreAmountProviderTests.swift */,
 			);
 			path = "Theatrical-Players-Refactoring-Kata";
 			sourceTree = "<group>";
@@ -222,6 +225,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8C7BE0D72C169148000D9945 /* GenreAmountProviderTests.swift in Sources */,
 				104F7D8323282F2900665957 /* StatementPrinterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/GenreAmountProviderTests.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/GenreAmountProviderTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import Theatrical_Players_Refactoring_Kata
+
+class GenreAmountProviderTests: XCTestCase {
+    func test_amountFor_throwsErrorOnNewPlayGenre() throws {
+        let sut = GenreCostProvider()
+        
+        XCTAssertThrowsError(try sut.amountFor(genre: "always new"))
+    }
+    
+    func test_amountFor_hasCorrectCostWhenHighVolume() throws {
+        let sut = GenreCostProvider()
+        let cases: [(String, Int)] = [
+            ("tragedy", 55),
+            ("comedy", 35)
+        ]
+        let expected = [
+            "tragedy": 650,
+            "comedy": 580
+        ]
+        
+        for testCase in cases {
+            XCTAssertEqual(try sut.amountFor(genre: testCase.0)(testCase.1), expected[testCase.0]!)
+        }
+    }
+}

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/GenreAmountProviderTests.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/GenreAmountProviderTests.swift
@@ -3,13 +3,13 @@ import XCTest
 
 class GenreAmountProviderTests: XCTestCase {
     func test_amountFor_throwsErrorOnNewPlayGenre() throws {
-        let sut = GenreCostProvider()
+        let sut = GenreDollarCostProvider()
         
         XCTAssertThrowsError(try sut.amountFor(genre: "always new"))
     }
     
     func test_amountFor_hasCorrectCostWhenHighVolume() throws {
-        let sut = GenreCostProvider()
+        let sut = GenreDollarCostProvider()
         let cases: [(String, Int)] = [
             ("tragedy", 55),
             ("comedy", 35)

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/GenreCostProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/GenreCostProvider.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+struct GenreCostProvider: GenreAmountProvider {
+    func amountFor(genre: String) throws -> AmountCalculator {
+        switch (genre) {
+        case "tragedy" :
+            return { attendance in
+                var result = 40000
+                if (attendance > 30) {
+                    result += 1000 * (attendance - 30)
+                }
+                return result / 100
+            }
+        case "comedy" :
+            return { attendance in
+                var result = 30000
+                if (attendance > 20) {
+                    result += 10000 + 500 * (attendance - 20)
+                }
+                return (result + 300 * attendance) / 100
+            }
+        default:
+            throw GenreError.newGenre
+        }
+    }
+    
+    enum GenreError: Error {
+        case newGenre
+    }
+}

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/GenreDollarCostProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/GenreDollarCostProvider.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct GenreCostProvider: GenreAmountProvider {
+struct GenreDollarCostProvider: GenreAmountProvider {
     func amountFor(genre: String) throws -> AmountCalculator {
         switch (genre) {
         case "tragedy" :

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/Play.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/Play.swift
@@ -1,3 +1,3 @@
 struct Play {
-    let name, type: String
+    let name, genre: String
 }

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -26,6 +26,8 @@ struct StatementData {
 }
 
 class StatementPrinter: StatementProvider {
+    let genreCostProvider: GenreAmountProvider
+    
     func formattedStatement(from statementData: StatementData) -> String {
         var result = "Statement for \(statementData.customerName)\n"
         
@@ -41,6 +43,10 @@ class StatementPrinter: StatementProvider {
         result += "You earned \(statementData.totalVolumeCredits) credits\n"
         return result
     }
+    
+    init(genreCostProvider: GenreAmountProvider = GenreCostProvider()) {
+        self.genreCostProvider = genreCostProvider
+    }
 }
 
 extension StatementPrinter: StatementDataProvider {
@@ -55,7 +61,7 @@ extension StatementPrinter: StatementDataProvider {
         
         func statementCostLineData(_ performance: Performance) throws -> StatementData.Charge {
             (try playFor(playID: performance.playID).name,
-             try amountFor(genre: try playFor(playID: performance.playID).genre)(performance.audience),
+             try genreCostProvider.amountFor(genre: try playFor(playID: performance.playID).genre)(performance.audience),
              performance.audience)
         }
         
@@ -85,31 +91,6 @@ extension StatementPrinter: StatementDataProvider {
             }
             
             return play
-        }
-    }
-}
-
-extension StatementPrinter: GenreAmountProvider {
-    func amountFor(genre: String) throws -> AmountCalculator {
-        switch (genre) {
-        case "tragedy" :
-            return { attendance in
-                var result = 40000
-                if (attendance > 30) {
-                    result += 1000 * (attendance - 30)
-                }
-                return result / 100
-            }
-        case "comedy" :
-            return { attendance in
-                var result = 30000
-                if (attendance > 20) {
-                    result += 10000 + 500 * (attendance - 20)
-                }
-                return (result + 300 * attendance) / 100
-            }
-        default:
-            throw UnknownTypeError.unknownTypeError("unknown type: \(genre)")
         }
     }
 }

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -86,11 +86,7 @@ extension StatementPrinter: StatementDataProvider {
             
             switch (genre) {
             case "tragedy" :
-                cost = 40000
-                if (attendance > 30) {
-                    cost += 1000 * (attendance - 30)
-                }
-                
+                cost = try costCalculationFor(genre: genre)(attendance)
             case "comedy" :
                 cost = 30000
                 if (attendance > 20) {
@@ -102,6 +98,22 @@ extension StatementPrinter: StatementDataProvider {
             }
             
             return cost / 100
+        }
+        
+        typealias AmountCalculator = (Int) -> Int
+        func costCalculationFor(genre: String) throws -> AmountCalculator {
+            switch (genre) {
+            case "tragedy" :
+                return { attendance in
+                    var result = 40000
+                    if (attendance > 30) {
+                        result += 1000 * (attendance - 30)
+                    }
+                    return result
+                }
+            default:
+                throw UnknownTypeError.unknownTypeError("unknown type: \(genre)")
+            }
         }
     }
 }

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -6,6 +6,12 @@ protocol StatementDataProvider {
     func statementData(_ invoice: Invoice, _ plays: Dictionary<String, Play>) throws -> StatementData
 }
 
+protocol GenreAmountProvider {
+    typealias AmountCalculator = (Int) -> Int
+    
+    func amountFor(genre: String) throws -> AmountCalculator
+}
+
 struct StatementData {
     typealias Charge = (
         playName: String,
@@ -80,29 +86,30 @@ extension StatementPrinter: StatementDataProvider {
             
             return play
         }
-        
-        typealias AmountCalculator = (Int) -> Int
-        func amountFor(genre: String) throws -> AmountCalculator {
-            switch (genre) {
-            case "tragedy" :
-                return { attendance in
-                    var result = 40000
-                    if (attendance > 30) {
-                        result += 1000 * (attendance - 30)
-                    }
-                    return result / 100
+    }
+}
+
+extension StatementPrinter: GenreAmountProvider {
+    func amountFor(genre: String) throws -> AmountCalculator {
+        switch (genre) {
+        case "tragedy" :
+            return { attendance in
+                var result = 40000
+                if (attendance > 30) {
+                    result += 1000 * (attendance - 30)
                 }
-            case "comedy" :
-                return { attendance in
-                    var result = 30000
-                    if (attendance > 20) {
-                        result += 10000 + 500 * (attendance - 20)
-                    }
-                    return (result + 300 * attendance) / 100
-                }
-            default:
-                throw UnknownTypeError.unknownTypeError("unknown type: \(genre)")
+                return result / 100
             }
+        case "comedy" :
+            return { attendance in
+                var result = 30000
+                if (attendance > 20) {
+                    result += 10000 + 500 * (attendance - 20)
+                }
+                return (result + 300 * attendance) / 100
+            }
+        default:
+            throw UnknownTypeError.unknownTypeError("unknown type: \(genre)")
         }
     }
 }

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -88,12 +88,7 @@ extension StatementPrinter: StatementDataProvider {
             case "tragedy" :
                 cost = try costCalculationFor(genre: genre)(attendance)
             case "comedy" :
-                cost = 30000
-                if (attendance > 20) {
-                    cost += 10000 + 500 * (attendance - 20)
-                }
-                cost += 300 * attendance
-                
+                cost = try costCalculationFor(genre: genre)(attendance)
             default : throw UnknownTypeError.unknownTypeError("unknown type: \(genre)")
             }
             
@@ -110,6 +105,14 @@ extension StatementPrinter: StatementDataProvider {
                         result += 1000 * (attendance - 30)
                     }
                     return result
+                }
+            case "comedy" :
+                return { attendance in
+                    var result = 30000
+                    if (attendance > 20) {
+                        result += 10000 + 500 * (attendance - 20)
+                    }
+                    return result + 300 * attendance
                 }
             default:
                 throw UnknownTypeError.unknownTypeError("unknown type: \(genre)")

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -44,7 +44,7 @@ class StatementPrinter: StatementProvider {
         return result
     }
     
-    init(genreCostProvider: GenreAmountProvider = GenreCostProvider()) {
+    init(genreCostProvider: GenreAmountProvider = GenreDollarCostProvider()) {
         self.genreCostProvider = genreCostProvider
     }
 }

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -49,7 +49,7 @@ extension StatementPrinter: StatementDataProvider {
         
         func statementCostLineData(_ performance: Performance) throws -> StatementData.Charge {
             (try playFor(playID: performance.playID).name,
-             try performanceDollarCostTotalFor(genre: try playFor(playID: performance.playID).type, attendance: performance.audience),
+             try amountFor(genre: try playFor(playID: performance.playID).type)(performance.audience),
              performance.audience)
         }
         
@@ -81,22 +81,8 @@ extension StatementPrinter: StatementDataProvider {
             return play
         }
         
-        func performanceDollarCostTotalFor(genre: String, attendance: Int) throws -> Int {
-            var cost: Int = 0
-            
-            switch (genre) {
-            case "tragedy" :
-                cost = try costCalculationFor(genre: genre)(attendance)
-            case "comedy" :
-                cost = try costCalculationFor(genre: genre)(attendance)
-            default : throw UnknownTypeError.unknownTypeError("unknown type: \(genre)")
-            }
-            
-            return cost / 100
-        }
-        
         typealias AmountCalculator = (Int) -> Int
-        func costCalculationFor(genre: String) throws -> AmountCalculator {
+        func amountFor(genre: String) throws -> AmountCalculator {
             switch (genre) {
             case "tragedy" :
                 return { attendance in
@@ -104,7 +90,7 @@ extension StatementPrinter: StatementDataProvider {
                     if (attendance > 30) {
                         result += 1000 * (attendance - 30)
                     }
-                    return result
+                    return result / 100
                 }
             case "comedy" :
                 return { attendance in
@@ -112,7 +98,7 @@ extension StatementPrinter: StatementDataProvider {
                     if (attendance > 20) {
                         result += 10000 + 500 * (attendance - 20)
                     }
-                    return result + 300 * attendance
+                    return (result + 300 * attendance) / 100
                 }
             default:
                 throw UnknownTypeError.unknownTypeError("unknown type: \(genre)")

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/StatementPrinter.swift
@@ -49,7 +49,7 @@ extension StatementPrinter: StatementDataProvider {
         
         func statementCostLineData(_ performance: Performance) throws -> StatementData.Charge {
             (try playFor(playID: performance.playID).name,
-             try amountFor(genre: try playFor(playID: performance.playID).type)(performance.audience),
+             try amountFor(genre: try playFor(playID: performance.playID).genre)(performance.audience),
              performance.audience)
         }
         
@@ -57,7 +57,7 @@ extension StatementPrinter: StatementDataProvider {
             var result = 0
             for performance in invoice.performances {
                 // add volume credits
-                result += volumeCreditsFor(genre: try playFor(playID: performance.playID).type, audienceCount: performance.audience)
+                result += volumeCreditsFor(genre: try playFor(playID: performance.playID).genre, audienceCount: performance.audience)
             }
             
             return result

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
@@ -2,30 +2,6 @@
 import XCTest
 @testable import Theatrical_Players_Refactoring_Kata
 
-class GenreAmountProviderTests: XCTestCase {
-    func test_amountFor_throwsErrorOnNewPlayGenre() throws {
-        let sut = GenreCostProvider()
-        
-        XCTAssertThrowsError(try sut.amountFor(genre: "always new"))
-    }
-    
-    func test_amountFor_hasCorrectCostWhenHighVolume() throws {
-        let sut = GenreCostProvider()
-        let cases: [(String, Int)] = [
-            ("tragedy", 55),
-            ("comedy", 35)
-        ]
-        let expected = [
-            "tragedy": 650, 
-            "comedy": 580
-        ]
-        
-        for testCase in cases {
-            XCTAssertEqual(try sut.amountFor(genre: testCase.0)(testCase.1), expected[testCase.0]!)
-        }
-    }
-}
-
 class StatementPrinterTests: XCTestCase {
     func test_exampleStatement() throws {
         

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
@@ -4,7 +4,26 @@ import XCTest
 
 struct GenreCostProvider: GenreAmountProvider {
     func amountFor(genre: String) throws -> AmountCalculator {
-        throw GenreError.newGenre
+        switch (genre) {
+        case "tragedy" :
+            return { attendance in
+                var result = 40000
+                if (attendance > 30) {
+                    result += 1000 * (attendance - 30)
+                }
+                return result / 100
+            }
+        case "comedy" :
+            return { attendance in
+                var result = 30000
+                if (attendance > 20) {
+                    result += 10000 + 500 * (attendance - 20)
+                }
+                return (result + 300 * attendance) / 100
+            }
+        default:
+            throw GenreError.newGenre
+        }
     }
     
     enum GenreError: Error {
@@ -17,6 +36,12 @@ class GenreAmountProviderTests: XCTestCase {
         let sut = GenreCostProvider()
         
         XCTAssertThrowsError(try sut.amountFor(genre: "always new"))
+    }
+    
+    func test_amountFor_hasCorrectCalculationWhenGenreIsTragedy() throws {
+        let sut = GenreCostProvider()
+
+        XCTAssertEqual(try sut.amountFor(genre: "tragedy")(55), 650)
     }
 }
 

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
@@ -4,7 +4,6 @@ import XCTest
 
 class StatementPrinterTests: XCTestCase {
     func test_exampleStatement() throws {
-        
         let expected = """
             Statement for BigCo
               Hamlet: $650.00 (55 seats)

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
@@ -16,9 +16,9 @@ class StatementPrinterTests: XCTestCase {
             """
         
         let plays = [
-            "hamlet": Play(name: "Hamlet", type: "tragedy"),
-            "as-like": Play(name: "As You Like It", type: "comedy"),
-            "othello": Play(name: "Othello", type: "tragedy")
+            "hamlet": Play(name: "Hamlet", genre: "tragedy"),
+            "as-like": Play(name: "As You Like It", genre: "comedy"),
+            "othello": Play(name: "Othello", genre: "tragedy")
         ]
         
         let invoice = Invoice(
@@ -39,8 +39,8 @@ class StatementPrinterTests: XCTestCase {
     
     func test_statementWithNewPlayTypes() {
         let plays = [
-            "henry-v": Play(name: "Henry V", type: "history"),
-            "as-like": Play(name: "As You Like It", type: "pastoral")
+            "henry-v": Play(name: "Henry V", genre: "history"),
+            "as-like": Play(name: "As You Like It", genre: "pastoral")
         ]
         
         let invoice = Invoice(
@@ -57,8 +57,8 @@ class StatementPrinterTests: XCTestCase {
     
     func test_print_throwsErrorOnUnkownPlayType() {
         let plays = [
-            "hamlet": Play(name: "Hamlet", type: "tragedy"),
-            "as-like": Play(name: "As You Like It", type: "comedy")
+            "hamlet": Play(name: "Hamlet", genre: "tragedy"),
+            "as-like": Play(name: "As You Like It", genre: "comedy")
         ]
         
         let invoice = Invoice(

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
@@ -2,35 +2,6 @@
 import XCTest
 @testable import Theatrical_Players_Refactoring_Kata
 
-struct GenreCostProvider: GenreAmountProvider {
-    func amountFor(genre: String) throws -> AmountCalculator {
-        switch (genre) {
-        case "tragedy" :
-            return { attendance in
-                var result = 40000
-                if (attendance > 30) {
-                    result += 1000 * (attendance - 30)
-                }
-                return result / 100
-            }
-        case "comedy" :
-            return { attendance in
-                var result = 30000
-                if (attendance > 20) {
-                    result += 10000 + 500 * (attendance - 20)
-                }
-                return (result + 300 * attendance) / 100
-            }
-        default:
-            throw GenreError.newGenre
-        }
-    }
-    
-    enum GenreError: Error {
-        case newGenre
-    }
-}
-
 class GenreAmountProviderTests: XCTestCase {
     func test_amountFor_throwsErrorOnNewPlayGenre() throws {
         let sut = GenreCostProvider()

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
@@ -38,16 +38,20 @@ class GenreAmountProviderTests: XCTestCase {
         XCTAssertThrowsError(try sut.amountFor(genre: "always new"))
     }
     
-    func test_amountFor_hasCorrectCalculationWhenGenreIsTragedy() throws {
+    func test_amountFor_hasCorrectCostWhenHighVolume() throws {
         let sut = GenreCostProvider()
-
-        XCTAssertEqual(try sut.amountFor(genre: "tragedy")(55), 650)
-    }
-    
-    func test_amountFor_hasCorrectCalculationWhenGenreIsComedy() throws {
-        let sut = GenreCostProvider()
+        let cases: [(String, Int)] = [
+            ("tragedy", 55),
+            ("comedy", 35)
+        ]
+        let expected = [
+            "tragedy": 650, 
+            "comedy": 580
+        ]
         
-        XCTAssertEqual(try sut.amountFor(genre: "comedy")(35), 580)
+        for testCase in cases {
+            XCTAssertEqual(try sut.amountFor(genre: testCase.0)(testCase.1), expected[testCase.0]!)
+        }
     }
 }
 

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
@@ -2,6 +2,24 @@
 import XCTest
 @testable import Theatrical_Players_Refactoring_Kata
 
+struct GenreCostProvider: GenreAmountProvider {
+    func amountFor(genre: String) throws -> AmountCalculator {
+        throw GenreError.newGenre
+    }
+    
+    enum GenreError: Error {
+        case newGenre
+    }
+}
+
+class GenreAmountProviderTests: XCTestCase {
+    func test_amountFor_throwsErrorOnNewPlayGenre() throws {
+        let sut = GenreCostProvider()
+        
+        XCTAssertThrowsError(try sut.amountFor(genre: "always new"))
+    }
+}
+
 class StatementPrinterTests: XCTestCase {
     func test_exampleStatement() throws {
         

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
@@ -43,6 +43,12 @@ class GenreAmountProviderTests: XCTestCase {
 
         XCTAssertEqual(try sut.amountFor(genre: "tragedy")(55), 650)
     }
+    
+    func test_amountFor_hasCorrectCalculationWhenGenreIsComedy() throws {
+        let sut = GenreCostProvider()
+        
+        XCTAssertEqual(try sut.amountFor(genre: "comedy")(35), 580)
+    }
 }
 
 class StatementPrinterTests: XCTestCase {


### PR DESCRIPTION
### TL;DR

Added `GenreDollarCostProvider` and `GenreAmountProviderTests`

### What changed?

Added `GenreDollarCostProvider` struct and `GenreAmountProviderTests` class with related functionality.

### How to test?

Run the tests in `GenreAmountProviderTests`.

### Why make this change?

To abstract amount calculation and separate that responsibility from selecting a calculation to be done for a specific genre. This makes it easier to add new genres because genre specific calculations are decoupled from formatting and can be tested in isolation
---

Encapsulate calculation of cost for tragedy genre performances in `AmountCalculator`

Encapsulate comedy genre cost calculation

Replace `performanceDollarCostTotalFor` with more generic `amountFor(genre:` to separate concerns of genre based calculation and `amount` product for attendance count

Rename `Play.type` to `genre`

Encapsulate cost calculation in `<GenreAmountProvider>` protocol conformance

`GenreCostProvider.amountFor` genre throws error whenever a new (default case) value is encountered. This struct is going to take the responsibility for calculating amounts from `StatementPrinter` so that new genres can be added, with tests, more easily by isolating the logic referencing them.

Copy cost calculation to `GenreProvider`. It provides the correct cost amount for tragedy performances

Correct cost is provided for comedy genre performances

Consolidate test cases into high volume cost test

Move `GenreCostProvider` to prod

Move `GenreAmountProviderTests` to own file

Remove cost responsibility (`<GenreAmountProvider>`) from `StatementPrinter` by dependency injecting `GenreCostProvider`

Rename to dollar cost provider for more accurate description of functionality