### PR TITLE
Add support for pastoral genre

### DIFF
--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/GenreAmountProviderTests.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/GenreAmountProviderTests.swift
@@ -23,4 +23,18 @@ class GenreAmountProviderTests: XCTestCase {
             XCTAssertEqual(try sut.amountFor(genre: testCase.0)(testCase.1), expected[testCase.0]!)
         }
     }
+    
+    func test_amountFor_hasCorrectCostWhenBaseVolume() throws {
+        let sut = GenreDollarCostProvider()
+        let cases: [(String, Int)] = [
+            ("pastoral", 30)
+        ]
+        let expected = [
+            "pastoral": 400
+        ]
+        
+        for testCase in cases {
+            XCTAssertEqual(try sut.amountFor(genre: testCase.0)(testCase.1), expected[testCase.0]!)
+        }
+    }
 }

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/GenreAmountProviderTests.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/GenreAmountProviderTests.swift
@@ -27,10 +27,12 @@ class GenreAmountProviderTests: XCTestCase {
     func test_amountFor_hasCorrectCostWhenBaseVolume() throws {
         let sut = GenreDollarCostProvider()
         let cases: [(String, Int)] = [
-            ("pastoral", 30)
+            ("pastoral", 30),
+            ("history", 30)
         ]
         let expected = [
-            "pastoral": 400
+            "pastoral": 400,
+            "history": 400
         ]
         
         for testCase in cases {

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/GenreDollarCostProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/GenreDollarCostProvider.swift
@@ -3,7 +3,7 @@ import Foundation
 struct GenreDollarCostProvider: GenreAmountProvider {
     func amountFor(genre: String) throws -> AmountCalculator {
         switch (genre) {
-        case "tragedy", "pastoral" :
+        case "tragedy", "pastoral", "history" :
             return { attendance in
                 var result = 40000
                 if (attendance > 30) {

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/GenreDollarCostProvider.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-Kata/GenreDollarCostProvider.swift
@@ -3,7 +3,7 @@ import Foundation
 struct GenreDollarCostProvider: GenreAmountProvider {
     func amountFor(genre: String) throws -> AmountCalculator {
         switch (genre) {
-        case "tragedy" :
+        case "tragedy", "pastoral" :
             return { attendance in
                 var result = 40000
                 if (attendance > 30) {

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import Theatrical_Players_Refactoring_Kata
 
 class StatementPrinterTests: XCTestCase {
-    func test_exampleStatement() throws {
+    func test_formattedStatement_generatesPlainTextFormatString() throws {
         let expected = """
             Statement for BigCo
               Hamlet: $650.00 (55 seats)

--- a/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
+++ b/Theatrical-Players-Refactoring-Kata/Theatrical-Players-Refactoring-KataTests/StatementPrinterTests.swift
@@ -38,8 +38,8 @@ class StatementPrinterTests: XCTestCase {
     
     func test_statementWithNewPlayTypes() {
         let plays = [
-            "henry-v": Play(name: "Henry V", genre: "history"),
-            "as-like": Play(name: "As You Like It", genre: "pastoral")
+            "henry-v": Play(name: "Henry V", genre: "always new"),
+            "as-like": Play(name: "As You Like It", genre: "always new")
         ]
         
         let invoice = Invoice(


### PR DESCRIPTION
This pull request includes updates to three files: `GenreAmountProviderTests.swift`, `GenreDollarCostProvider.swift`, and `StatementPrinterTests.swift`. 

The changes involve adding tests for new genres ('pastoral' and 'history') in the GenreDollarCostProvider and updating test names in the StatementPrinterTests to better reflect their purpose.

---

Add support for pastoral genre

Add support for history genre. Update integration test to use "always new" when testing new play genre error behavior

Rename test to reflect the plain text format it is checking for